### PR TITLE
prius_description: 0.0.2-1 in 'melodic/distribution.yaml' [bloom]

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3596,6 +3596,12 @@ repositories:
       url: https://github.com/PilzDE/prbt_grippers.git
       version: kinetic-devel
     status: developed
+  prius_description:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/RonaldEnsing/prius_description-release.git
+      version: 0.0.2-1
   py_trees:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `prius_description` to `0.0.2-1`:

- upstream repository: git@gitlab.tudelft.nl:intelligent-vehicles/ros-prius_description.git
- release repository: https://github.com/RonaldEnsing/prius_description-release.git
- distro file: `melodic/distribution.yaml`
- bloom version: `0.6.9`
- previous version for package: `null`

## prius_description

```
* Merge branch 'calibration-update' into 'master'
  Update with calibration as performed later today.
  See merge request intelligent-vehicles/ros-prius_description!7
* Update with calibration as performed later today.
* Merge branch 'calibration-update' into 'master'
  Update with calibration as performed today.
  See merge request intelligent-vehicles/ros-prius_description!6
* Update with calibration as performed today.
* Merge branch 'radar-pose-calibration' into 'master'
  Update radar pose with updated urdf_calibration tool
  See merge request intelligent-vehicles/ros-prius_description!5
* Update radar pose with updated urdf_calibration tool
* Merge branch 'calibration' into 'master'
  Update urdf with calibration and removing unused links
  See merge request intelligent-vehicles/ros-prius_description!4
* Add an_device.
* Remove unused links from urdf.
* Calibrate radar to lidar.
* Calibrate camera to lidar.
* Update urdf without calibration, should be equivalent.
* Calibrate camera and radar to velodyne.
* Merge branch 'fix-camera-urdf-entry' into 'master'
  Add camera in urdf
  See merge request intelligent-vehicles/ros-prius_description!3
* Add camera in urdf.
* Merge branch 'master' of gitlab.3me.tudelft.nl:intelligent-vehicles/ros-prius_description
* Install urdf file in CMakeLists.txt.
* Add an_device temporarily.
* Connect gps and imu link to chassis.
* Add gps and imu link.
* added front center right radar location and improved lidar position
* but base_link on rear axis, rotate base_link to have x=longitudinal, y=lateral orientation
* put left/right_camera_link relative to front_camera_link in URDF as 3ME-TUD Prius stereo setup
* initial commit, based on github:osrf/car_demo
* Contributors: Franciscus Everdij, Frank Everdij, Joris Domhof, Julian Kooij, Ronald Ensing
```
